### PR TITLE
Parsing custom fields from extension schema

### DIFF
--- a/src/FasTnT.Formatters.Xml/Parsers/XmlEventsParser.cs
+++ b/src/FasTnT.Formatters.Xml/Parsers/XmlEventsParser.cs
@@ -38,6 +38,11 @@ namespace FasTnT.Formatters.Xml.Requests
         {
             foreach(var node in root.Elements())
             {
+                if (node.Name.NamespaceName != XNamespace.None && node.Name.NamespaceName != XNamespace.Xmlns && node.Name.NamespaceName != EpcisNamespaces.Capture)
+                {
+                    epcisEvent.CustomFields.Add(ParseCustomField(node, epcisEvent, FieldType.EventExtension));
+                    continue;
+                }
                 switch (node.Name.LocalName)
                 {
                     case "eventTime":
@@ -116,11 +121,6 @@ namespace FasTnT.Formatters.Xml.Requests
 
         internal static CustomField ParseCustomField(XElement element, EpcisEvent epcisEvent, FieldType type)
         {
-            if (element.Name.Namespace == XNamespace.None || element.Name.Namespace == XNamespace.Xmlns || element.Name.NamespaceName == EpcisNamespaces.Capture)
-            {
-                throw new Exception($"Element '{element.Name.LocalName}' with namespace '{element.Name.NamespaceName}' not expected here.");
-            }
-
             var field = new CustomField
             {
                 Id = _customCounter++,
@@ -142,7 +142,7 @@ namespace FasTnT.Formatters.Xml.Requests
                 }
             }
 
-            foreach (var attribute in element.Attributes().Where(x => x.Name.Namespace != XNamespace.None && x.Name.Namespace != XNamespace.Xmlns && x.Name.NamespaceName != EpcisNamespaces.Capture))
+            foreach (var attribute in element.Attributes())
             {
                 var attributeField = new CustomField
                 {


### PR DESCRIPTION
Events parser had some troubles parsing custom fields from extension schema 

- overlapping names: `epcList` was defined both in epcis and vendor specification
- schemaless attributes:  `<cds:itemProductID measurementUnitCode="20">400</cds:itemProductID>`

Sample data:

	<?xml version="1.0" encoding="UTF-8"?>
	<epcis:EPCISDocument 
		xmlns:epcis="urn:epcglobal:epcis:xsd:1" 
		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
		xmlns:tpd="http://example.com/schemas/v1.0/tpd-extension/" 
		xmlns:cds="http://example.com/schemas/v1.0/cds/" 
		creationDate="2018-11-28T12:00:00Z" schemaVersion="1.2">
		<EPCISBody>
			<EventList>
				<ObjectEvent>
					<!--standard data example -->
					<epcList>
						<epc>urn:epc:id:sgtin:0614141.107346.2018</epc>
						<epc>urn:epc:id:sgtin:0614141.107346.2017</epc>
						<epc>urn:epc:id:sgtin:0614141.107346.2019</epc>
					</epcList>
					<action>OBSERVE</action>
					<bizStep>urn:epcglobal:cbv:bizstep:receiving</bizStep>
					<!--custom schemes -->
					<tpd:Message_Type>3-4</tpd:Message_Type>
					<tpd:UI_Type>3</tpd:UI_Type>
					<tpd:upUIs>
						<epc>urn:epc:id:sgtin:0614141.107346.2017</epc>
					</tpd:upUIs>
					<tpd:aUIs>
						<epc>urn:epc:id:sgtin:0614141.107346.2018</epc>
						<epc>urn:epc:id:sgtin:0614141.107346.2019</epc>
					</tpd:aUIs>
					<tpd:Arrival_comment>Comments</tpd:Arrival_comment>
					<cds:epcList>
						<cds:epcExtension>
							<cds:epc>urn:epc:id:sgtin:0614141.107346.2018</cds:epc>
							<cds:lotNumber>12345678</cds:lotNumber>
							<cds:itemProductID measurementUnitCode="20">400</cds:itemProductID>
						</cds:epcExtension>
						<cds:epcExtension>
							<cds:epc>urn:epc:id:sgtin:0614141.107346.2018</cds:epc>
							<cds:lotNumber>12345678</cds:lotNumber>
							<cds:itemProductID measurementUnitCode="20">400</cds:itemProductID>
						</cds:epcExtension>
					</cds:epcList>
				</ObjectEvent>
			</EventList>
		</EPCISBody>
	</epcis:EPCISDocument>