### PR TITLE
Validate XML requests

### DIFF
--- a/src/FasTnT.Formatters.Xml/Validation/XmlHttpRequestValidator.cs
+++ b/src/FasTnT.Formatters.Xml/Validation/XmlHttpRequestValidator.cs
@@ -9,12 +9,12 @@ using MoreLinq;
 
 namespace FasTnT.Formatters.Xml.Validation
 {
-    public class XmlHttpRequestValidator : IRequestValidator
+    public class XmlDocumentParser
     {
-        public static XmlHttpRequestValidator Instance { get; } = new XmlHttpRequestValidator();
+        public static XmlDocumentParser Instance { get; } = new XmlDocumentParser();
         private readonly XmlSchemaSet _schema;
 
-        private XmlHttpRequestValidator()
+        private XmlDocumentParser()
         {
             _schema = new XmlSchemaSet();
 
@@ -27,11 +27,12 @@ namespace FasTnT.Formatters.Xml.Validation
             _schema.Compile();
         }
 
-        public void Validate(Stream input)
+        public XDocument Load(Stream input)
         {
-            var document = XDocument.Load(new StreamReader(input));
-
+            var document = XDocument.Load(input);
             document.Validate(_schema, (e, t) => { if (t.Exception != null) throw t.Exception; });
+
+            return document;
         }
     }
 }

--- a/src/FasTnT.Formatters.Xml/XmlQueryFormatter.cs
+++ b/src/FasTnT.Formatters.Xml/XmlQueryFormatter.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Xml.Linq;
 using FasTnT.Formatters.Xml.Requests;
+using FasTnT.Formatters.Xml.Validation;
 using FasTnT.Model.Queries;
 
 namespace FasTnT.Formatters.Xml
@@ -12,7 +13,7 @@ namespace FasTnT.Formatters.Xml
     {
         public EpcisQuery Read(Stream input)
         {
-            var document = XDocument.Load(input);
+            var document = XmlDocumentParser.Instance.Load(input);
 
             if (document.Root.Name.LocalName == "EPCISQueryDocument")
             {

--- a/src/FasTnT.Formatters.Xml/XmlRequestFormatter.cs
+++ b/src/FasTnT.Formatters.Xml/XmlRequestFormatter.cs
@@ -8,6 +8,7 @@ using System.Xml.XPath;
 using FasTnT.Domain;
 using FasTnT.Formatters.Xml.Requests;
 using FasTnT.Formatters.Xml.Responses;
+using FasTnT.Formatters.Xml.Validation;
 
 namespace FasTnT.Formatters.Xml
 {
@@ -15,7 +16,7 @@ namespace FasTnT.Formatters.Xml
     {
         public Request Read(Stream input)
         {
-            var document = XDocument.Load(input);
+            var document = XmlDocumentParser.Instance.Load(input);
 
             if (document.Root.Name == XName.Get("EPCISDocument", EpcisNamespaces.Capture))
             {

--- a/src/FasTnT.Formatters/IRequestValidator.cs
+++ b/src/FasTnT.Formatters/IRequestValidator.cs
@@ -1,9 +1,0 @@
-﻿using System.IO;
-
-namespace FasTnT.Formatters
-{
-    public interface IRequestValidator
-    {
-        void Validate(Stream input);
-    }
-}


### PR DESCRIPTION
Use GS1 XSD documents to validate capture/query requests